### PR TITLE
Fix usage of commitlint format package

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const chalk = require('chalk')
 const builder = require('junit-report-builder')
-const format = require('@commitlint/format')
+const format = require('@commitlint/format').default
 
 const logger = require('./logger')
 const { STATUSES } = require('./constants')
@@ -12,7 +12,7 @@ function buildJunitFile(lintFailures) {
     lintFailures.forEach(failure => {
         const lines = [
             `input: ${failure.input}`,
-            ...format(failure, { color: false }),
+            format(failure, { color: false }),
         ]
         suite
             .testCase()


### PR DESCRIPTION
The format package returns a string: https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/format/src/format.ts#L51

And it is compiled as a esModule so we have to take the default prop after requiring. This explains the error message seen in #18, but does not explain why the code was actually being executed in the first place on branches that should not have failed the check. Once we get this change out, we'll see what the real failures are.