### PR TITLE
chore: changed multiple commits failure message

### DIFF
--- a/.github/workflows/commit-watch.yml
+++ b/.github/workflows/commit-watch.yml
@@ -1,7 +1,7 @@
 name: Commit Watch
 
 on:
-  - pull_request_target
+  - pull_request
 
 env:
   CI: 1

--- a/.github/workflows/commit-watch.yml
+++ b/.github/workflows/commit-watch.yml
@@ -1,7 +1,7 @@
 name: Commit Watch
 
 on:
-  - pull_request
+  - pull_request_target
 
 env:
   CI: 1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 
 on:
-  - pull_request_target
+  - pull_request
 
 env:
   CI: 1

--- a/src/getCommitResults.js
+++ b/src/getCommitResults.js
@@ -10,7 +10,9 @@ const getSingleCommitLintFailedMessage = commitResult =>
     `Fix commit lint errors - "${commitResult.input}"`
 
 const getMultipleCommitLintsFailedMessage = () =>
-    'Multiple commit lint errors, run "make lint-commit-messages" locally'
+    'Multiple commit lint errors, please ensure your commit messages conform to the conventional commit spec.'
+
+const conventionalCommitSpecLink = "https://www.conventionalcommits.org/en/v1.0.0/"
 
 const getCommitLintResults = async () => {
     const messages = await getCommitMessages()
@@ -53,6 +55,7 @@ const getCommitResults = async () => {
             githubServicePromises.push(
                 githubService.fail({
                     message: getMultipleCommitLintsFailedMessage(),
+                    url: conventionalCommitSpecLink,
                 }),
             )
             const commitWatchMessage = getSingleCommitLintFailedMessage(

--- a/src/getCommitResults.js
+++ b/src/getCommitResults.js
@@ -12,7 +12,8 @@ const getSingleCommitLintFailedMessage = commitResult =>
 const getMultipleCommitLintsFailedMessage = () =>
     'Multiple commit lint errors, please ensure your commit messages conform to the conventional commit spec.'
 
-const conventionalCommitSpecLink = "https://www.conventionalcommits.org/en/v1.0.0/"
+const conventionalCommitSpecLink =
+    'https://www.conventionalcommits.org/en/v1.0.0/'
 
 const getCommitLintResults = async () => {
     const messages = await getCommitMessages()

--- a/src/tests/integration.test.js
+++ b/src/tests/integration.test.js
@@ -110,6 +110,23 @@ describe('Integration', () => {
             expect(requests[1].state).toEqual('failure')
         })
 
+        it('reports mutiple commit failures to github with correct message', async () => {
+            mockMessages(['missing prefix', 'bad commit'])
+            await mainSafe()
+
+            const requests = mockAxios.history.post.map(r => getRequestData(r))
+            expect(requests).toHaveLength(3)
+            expect(requests[0].state).toEqual('pending')
+            expect(requests[1].state).toEqual('failure')
+            expect(requests[2].state).toEqual('failure')
+            expect(requests[2].description).toEqual(
+                'Multiple commit lint errors, please ensure your commit messages conform to the conventional commit spec.',
+            )
+            expect(requests[2].target_url).toEqual(
+                'https://www.conventionalcommits.org/en/v1.0.0/',
+            )
+        })
+
         it('reports success to github', async () => {
             mockMessages(['chore: good message'])
             await mainSafe()


### PR DESCRIPTION
## Description

Changed the multiple commit failure message to add a target_url of the conventional commit specs.
