### PR TITLE
Update failure message test

### DIFF
--- a/.github/workflows/commit-watch.yml
+++ b/.github/workflows/commit-watch.yml
@@ -1,7 +1,7 @@
 name: Commit Watch
 
 on:
-  - pull_request_target
+  - pull_request
 
 env:
   CI: 1

--- a/.github/workflows/commit-watch.yml
+++ b/.github/workflows/commit-watch.yml
@@ -1,7 +1,7 @@
 name: Commit Watch
 
 on:
-  - pull_request
+  - pull_request_target
 
 env:
   CI: 1

--- a/src/getCommitResults.js
+++ b/src/getCommitResults.js
@@ -10,7 +10,9 @@ const getSingleCommitLintFailedMessage = commitResult =>
     `Fix commit lint errors - "${commitResult.input}"`
 
 const getMultipleCommitLintsFailedMessage = () =>
-    'Multiple commit lint errors, run "make lint-commit-messages" locally'
+    'Multiple commit lint errors, please ensure your commit messages conform to the conventional commit spec.'
+
+const conventionalCommitSpecLink = "https://www.conventionalcommits.org/en/v1.0.0/"
 
 const getCommitLintResults = async () => {
     const messages = await getCommitMessages()
@@ -53,6 +55,7 @@ const getCommitResults = async () => {
             githubServicePromises.push(
                 githubService.fail({
                     message: getMultipleCommitLintsFailedMessage(),
+                    url: conventionalCommitSpecLink,
                 }),
             )
             const commitWatchMessage = getSingleCommitLintFailedMessage(

--- a/src/getCommitResults.js
+++ b/src/getCommitResults.js
@@ -12,7 +12,8 @@ const getSingleCommitLintFailedMessage = commitResult =>
 const getMultipleCommitLintsFailedMessage = () =>
     'Multiple commit lint errors, please ensure your commit messages conform to the conventional commit spec.'
 
-const conventionalCommitSpecLink = "https://www.conventionalcommits.org/en/v1.0.0/"
+const conventionalCommitSpecLink =
+    'https://www.conventionalcommits.org/en/v1.0.0/'
 
 const getCommitLintResults = async () => {
     const messages = await getCommitMessages()

--- a/src/tests/integration.test.js
+++ b/src/tests/integration.test.js
@@ -110,6 +110,19 @@ describe('Integration', () => {
             expect(requests[1].state).toEqual('failure')
         })
 
+        it('reports mutiple commit failures to github with correct message', async () => {
+            mockMessages(['missing prefix', 'bad commit'])
+            await mainSafe()
+
+            const requests = mockAxios.history.post.map(r => getRequestData(r))
+            expect(requests).toHaveLength(3)
+            expect(requests[0].state).toEqual('pending')
+            expect(requests[1].state).toEqual('failure')
+            expect(requests[2].state).toEqual('failure')
+            expect(requests[2].description).toEqual('Multiple commit lint errors, please ensure your commit messages conform to the conventional commit spec.')
+            expect(requests[2].target_url).toEqual('https://www.conventionalcommits.org/en/v1.0.0/')
+        })
+
         it('reports success to github', async () => {
             mockMessages(['chore: good message'])
             await mainSafe()

--- a/src/tests/integration.test.js
+++ b/src/tests/integration.test.js
@@ -119,8 +119,12 @@ describe('Integration', () => {
             expect(requests[0].state).toEqual('pending')
             expect(requests[1].state).toEqual('failure')
             expect(requests[2].state).toEqual('failure')
-            expect(requests[2].description).toEqual('Multiple commit lint errors, please ensure your commit messages conform to the conventional commit spec.')
-            expect(requests[2].target_url).toEqual('https://www.conventionalcommits.org/en/v1.0.0/')
+            expect(requests[2].description).toEqual(
+                'Multiple commit lint errors, please ensure your commit messages conform to the conventional commit spec.',
+            )
+            expect(requests[2].target_url).toEqual(
+                'https://www.conventionalcommits.org/en/v1.0.0/',
+            )
         })
 
         it('reports success to github', async () => {


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Currently, when `commit-watch` encounters multiple lint failures, it displays a message telling the user to run a command that's available in Top Hat codebases. However, since `commit-watch` is open-source, said command is not guaranteed to be available in user's codebases. This PR fixes the message, as well as adds tests to ensure the correct message is displayed.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #60, updates the failure message for multiple lint failures.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
